### PR TITLE
layout.tex.erbを最新化

### DIFF
--- a/articles/layouts/layout.tex.erb
+++ b/articles/layouts/layout.tex.erb
@@ -226,6 +226,9 @@
 
 \reviewmainfont
 
+\frontmatter
+\pagenumbering{arabic}
+
 <% if values["titlepage"] %>
 <% if custom_titlepage %>
 <%= custom_titlepage %>
@@ -238,7 +241,8 @@
   \end{center}
   \clearpage
   <% end %>
-\thispagestyle{empty}
+\thispagestyle{plainhead}
+\setcounter{page}{1}
 \begin{center}%
   \mbox{} \vskip5zw
    \reviewtitlefont%
@@ -256,9 +260,6 @@
 \end{titlepage}
 <% end %>
 <% end %>
-
-\renewcommand{\chaptermark}[1]{{}}
-\frontmatter
 
 %%% originaltitle
 <% if values["originaltitlefile"] %>
@@ -279,8 +280,17 @@
 \tableofcontents
 <% end %>
 
-\renewcommand{\chaptermark}[1]{\markboth{\prechaptername\thechapter\postchaptername~#1}{}}
+\begingroup
+  \cleardoublepage
+  \edef\continuenumber{\endgroup
+    \noexpand\mainmatter
+    \setcounter{page}{\the\value{page}}%
+  }
 \mainmatter
+\continuenumber
+
+\renewcommand{\chaptermark}[1]{\markboth{\prechaptername\thechapter\postchaptername~#1}{}}
+
 <%= values["chap_str"] %>
 \renewcommand{\chaptermark}[1]{\markboth{\appendixname\thechapter~#1}{}}
 \reviewappendix
@@ -313,7 +323,7 @@
 <%   else %>
 %% okuduke
 \reviewcolophon
-\thispagestyle{empty}
+\thispagestyle{plainhead}
 
 \vspace*{\fill}
 


### PR DESCRIPTION
古いバージョンのlayout.tex.erbを元にしていたので、最近追加されたAPPENDIXなどが使えていませんでした。
最新ソースからひっぱってきて、通しノンブルの調整だけいれてあります。
著者紹介が付録になっちゃってたのが直ったりしてます。
