### PR TITLE
@<code>内でスペースが消失する問題対応

### DIFF
--- a/articles/sty/techbooster-doujin.sty
+++ b/articles/sty/techbooster-doujin.sty
@@ -75,9 +75,12 @@
 \setlength{\voffset}{-1in}
 \renewcommand{\baselinestretch}{0.96}
 
+\usepackage{fancyvrb}
+\VerbatimFootnotes
 \usepackage{seqsplit}
 \let\textttorg=\texttt
-\def\texttt#1{\textttorg{\seqsplit{#1\relax}}}
+\def\texttt{\begingroup\obeyspaces\do@texttt}
+\def\do@texttt#1{\textttorg{\seqsplit{#1\relax}}\endgroup}
 
 \newcommand{\captionsize}{\fontsize{9}{9}\selectfont}
 \newlength{\captionnumwidth}


### PR DESCRIPTION
\footnoteでcatcodeが変更できない制約を回避するのにfancyvrbを使っていて、dvipdfmxで警告が出ます。
PDFのdiffを見る限り実害ははなさそう。
