### PR TITLE
最近のRubyで動くようBundlerのバージョン指定を削除

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,3 @@ DEPENDENCIES
   playwright-runner
   rake
   review (= 5.8.0)
-
-BUNDLED WITH
-   1.15.3


### PR DESCRIPTION
このリポジトリをビルドするためにRe:VIEWをインストールする際、Ruby 3.2.2ではBundler 1.15.3が動かなかったので、とりあえずBundlerのバージョン指定を削除します。

（Bundler 2.4.xとかを指定した方が確実ではあるのですが、逆に古いRubyでは動かなくなるので日和りました…）